### PR TITLE
chore(doc): multiline code tags for build server doc

### DIFF
--- a/hacks/build_server.md
+++ b/hacks/build_server.md
@@ -1,16 +1,21 @@
 # Install git
+```
 sudo add-apt-repository -y ppa:git-core/ppa
 sudo apt install -y git
 git --version
+```
 
 # Install CMake
+```
 sudo wget -qO /etc/apt/trusted.gpg.d/kitware-key.asc https://apt.kitware.com/keys/kitware-archive-latest.asc
 echo "deb https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/kitware.list
 sudo apt update
 sudo apt install -y cmake
 cmake --version
+```
 
 # Install gcc-arm
+```
 #ARM_TOOLCHAIN_VERSION=$(curl -s https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads | grep -Po '<h4>Version \K.+(?=</h4>)')
 #curl -Lo gcc-arm-none-eabi.tar.xz "https://developer.arm.com/-/media/Files/downloads/gnu/10.3/binrel/arm-gnu-toolchain-10.3-x86_64-arm-none-eabi.tar.xz"
 
@@ -24,20 +29,28 @@ source /etc/profile
 arm-none-eabi-gcc --version
 arm-none-eabi-g++ --version
 rm -rf gcc-arm-none-eabi.tar.xzs
+```
 
 # Install pico sdk
+```
 sudo git clone https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk
 sudo git -C /opt/pico-sdk submodule update --init
 echo 'export PICO_SDK_PATH=/opt/pico-sdk' | sudo tee -a /etc/profile.d/pico-sdk.sh
 source /etc/profile.d/pico-sdk.sh
+```
 
 # Install BP5
+```
 sudo git clone https://github.com/DangerousPrototypes/BusPirate5-firmware.git bp5-main
 cd bp5-main
 md build
 cd build 
 cmake ..
-make 
+make
+```
+
+# Install build script and webhook
+```
 cd ~
 md webhook
 pip install virtualenv
@@ -51,8 +64,5 @@ pip3 install requests
 sudo iptables -A INPUT -p tcp --dport 80 -j ACCEPT
 sudo apt-get install iptables-persistent
 screen
-python3 webhook.py  
-
-
-
-
+python3 webhook.py
+```


### PR DESCRIPTION
Added multi-line code formatting tags + extra heading for the webhook.

I had just been reading https://forum.buspirate.com/t/build-server-setup-documentation/369 and noticed an extra heading, so added that in also. I also see there is some commented out lines present here not in the forum post, but I left the rest of the file intact. If you want this to be synced with the content of forum post will do that also. 